### PR TITLE
Solaris ld fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Mon Nov  1 04:46:19 2010  Ben Walton  <bwalton@artsci.utoronto.ca>
+
+	* configure.in: support -h for solaris linker when gcc not used
+
 Fri Aug 20 10:40:04 2010  Tanaka Akira  <akr@fsij.org>
 
 	* ext/pathname/pathname.c (path_expand_path): Pathname#expand_path

--- a/configure.in
+++ b/configure.in
@@ -2152,6 +2152,8 @@ AS_CASE("$enable_shared", [yes], [
 	LIBRUBY_ALIASES='lib$(RUBY_SO_NAME).so.$(MAJOR).$(MINOR).$(TEENY) lib$(RUBY_SO_NAME).so'
 	if test "$GCC" = yes; then
 	    LIBRUBY_DLDFLAGS="$DLDFLAGS "'-Wl,-h,$(@F)'
+	else
+	    LIBRUBY_DLDFLAGS="$DLDFLAGS "'-h $(@F)'
 	fi
 	XLDFLAGS="$XLDFLAGS "'-R${libdir}'
 	],


### PR DESCRIPTION
Hello,

This patch will make the linker on solaris embed the SONAME properly when using a compiler other than gcc.  It's a pretty trivial fix in configure.in.

I hope everything is appropriate for this pull request as this is my first submission to the ruby project.  Feel free to tell me there is something missing or wrong.

Thanks
-Ben
