### PR TITLE
Toy

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -476,9 +476,9 @@ class Pathname
     base_names.fill('..')
     relpath_names = base_names + dest_names
     if relpath_names.empty?
-      Pathname.new('.')
+      self.class.new('.')
     else
-      Pathname.new(File.join(*relpath_names))
+      self.class.new(File.join(*relpath_names))
     end
   end
 end

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -313,6 +313,10 @@ class TestPathname < Test::Unit::TestCase
   defassert_raise(:relative_path_from, ArgumentError, "a", "..")
   defassert_raise(:relative_path_from, ArgumentError, ".", "..")
 
+  define_assertion(:relative_path_from) {
+    assert_instance_of(SuperPathname, SuperPathname.new('a').relative_path_from(SuperPathname.new('b')))
+  }
+
   def with_tmpchdir(base=nil)
     Dir.mktmpdir(base) {|d|
       d = Pathname.new(d).realpath.to_s


### PR DESCRIPTION
Fixed Pathname `+` and `relative_path_from` methods: they where returning instance of Pathname even if called for instance of Pathname subclass.
