### PR TITLE
Syslog test fixes

### DIFF
--- a/test/test_syslog.rb
+++ b/test/test_syslog.rb
@@ -135,8 +135,9 @@ class TestSyslog < Test::Unit::TestCase
     stderr[1].close
     Process.waitpid(pid)
 
-    # LOG_PERROR is not yet implemented on Cygwin.
-    return if RUBY_PLATFORM =~ /cygwin/
+    # LOG_PERROR is not implemented on Cygwin or Solaris.  Only test
+    # these on systems that define it.
+    return unless Syslog.const_defined?(:LOG_PERROR)
 
     2.times {
       assert_equal("syslog_test: test1 - hello, world!\n", stderr[0].gets)


### PR DESCRIPTION
Hi,

I'm attempting to get 1.9.2 packaged for OpenCSW and the test suite was failing on the use of LOG_PERROR in the syslog test suite (among other places).  The two patches on this branch address the problems adequately, I believe.

Thanks
-Ben
