### PR TITLE
ERB::Util.url_encode should not escape unreserved characters (including tilde)

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -928,7 +928,7 @@ class ERB
     #   Programming%20Ruby%3A%20%20The%20Pragmatic%20Programmer%27s%20Guide
     #
     def url_encode(s)
-      s.to_s.dup.force_encoding("ASCII-8BIT").gsub(/[^a-zA-Z0-9_\-.]/n) {
+      s.to_s.dup.force_encoding("ASCII-8BIT").gsub(/[^a-zA-Z0-9_\-.~]/n) {
         sprintf("%%%02X", $&.unpack("C")[0])
       }
     end

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -441,6 +441,10 @@ EOS
 
     assert_equal("%A5%B5%A5%F3%A5%D7%A5%EB",
                  ERB::Util.url_encode("\xA5\xB5\xA5\xF3\xA5\xD7\xA5\xEB".force_encoding("EUC-JP")))
+
+    assert_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+                 ERB::Util.url_encode("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"),
+                 "should not escape any unreserved characters, as per RFC3986 Section 2.3")
   end
 
   def test_percent_after_etag


### PR DESCRIPTION
Previously, `ERB::Util.url_encode` was escaping tilde (~) where it should not have. 

This fixes that behaviour so that it now correctly avoids escaping all reserved uncharacters as per RFC 3986, Section 2.3:
http://tools.ietf.org/html/rfc3986#section-2.3
