### PR TITLE
BigDecimal, jacobian dfdxi function gets stuck in an infinite loop 

### DIFF
--- a/ext/bigdecimal/lib/bigdecimal/jacobian.rb
+++ b/ext/bigdecimal/lib/bigdecimal/jacobian.rb
@@ -11,7 +11,7 @@
 #
 # f.zero:: returns 0.0
 # f.one:: returns 1.0
-# f.two:: returns 1.0
+# f.two:: returns 2.0
 # f.ten:: returns 10.0
 #
 # f.eps:: returns the convergence criterion (epsilon value) used to determine whether two values are considered equal. If |a-b| < epsilon, the two values are considered equal.

--- a/ext/bigdecimal/lib/bigdecimal/newton.rb
+++ b/ext/bigdecimal/lib/bigdecimal/newton.rb
@@ -18,7 +18,7 @@ require "bigdecimal/jacobian"
 #
 # f.zero:: returns 0.0
 # f.one:: returns 1.0
-# f.two:: returns 1.0
+# f.two:: returns 2.0
 # f.ten:: returns 10.0
 #
 # f.eps:: returns the convergence criterion (epsilon value) used to determine whether two values are considered equal. If |a-b| < epsilon, the two values are considered equal.


### PR DESCRIPTION
This occurs when a solution is not found for nlsolve. This seems to be due to a forgotten nRetry counter increment in the function dfdxi.   This problem is ni 1.9.2 till 1.9.3.   
